### PR TITLE
Previous commit raised bug on 'save as new' button. 

### DIFF
--- a/qshop/admin.py
+++ b/qshop/admin.py
@@ -4,7 +4,7 @@ from .models import (
     Parameter, ProductToParameter, ParameterValue
 )
 
-from .admin_forms import ProductToParameterFormset, CategoryForm, PriceForm, ProductAdminForm
+from .admin_forms import ProductToParameterFormset, CategoryForm, PriceForm, ProductAdminForm, ProductToParameterForm
 from .admin_filters import ProductCategoryListFilter
 
 from django.conf import settings
@@ -77,14 +77,14 @@ class ProductImageInline(getParentClass('TabularInline', ProductImage)):
 
 class ProductToParameterInline(getParentClass('TabularInline', ProductToParameter)):
     model = ProductToParameter
-    # formset = ProductToTypeFieldFormset
     extra = 0
     can_delete = False
-    readonly_fields = ('parameter',)
+    form = ProductToParameterForm
     formset = ProductToParameterFormset
+    readonly_fields = ('get_parameter_name',)
     fieldsets = (
         (None, {
-            'fields': ('parameter', 'value'),
+            'fields': ('get_parameter_name', 'parameter', 'value'),
         }),
     )
 
@@ -93,6 +93,11 @@ class ProductToParameterInline(getParentClass('TabularInline', ProductToParamete
 
     def get_queryset(self, request):
         return super(ProductToParameterInline).get_queryset(request).select_related('parameter')
+
+    def get_parameter_name(self, obj=None):
+        if obj:
+            return obj.parameter
+    get_parameter_name.short_description = 'Parameter'
 
 
 class ProductAdmin(getParentClass('ModelAdmin', Product)):

--- a/qshop/admin_forms.py
+++ b/qshop/admin_forms.py
@@ -30,6 +30,12 @@ class ProductToParameterFormset(BaseInlineFormSet):
         form.fields['value'].queryset = values
 
 
+class ProductToParameterForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super(ProductToParameterForm, self).__init__(*args, **kwargs)
+        self.fields['parameter'].widget = forms.HiddenInput()
+
+
 class CategoryForm(forms.Form):
     category = forms.ModelChoiceField(Menu.objects)
 

--- a/qshop/static/admin/qshop/js/products.js
+++ b/qshop/static/admin/qshop/js/products.js
@@ -1,11 +1,5 @@
 (function($) {
     $(function() {
-        $('#producttoparameter_set-group .field-parameter select').each(function(){
-            select = $(this);
-            select.hide();
-            $(select).after('<p>' + $('option:selected', select).html() + '</p>');
-        });
-
         $('#producttoparameter_set-group a.add-related').each(function(){
             id = $('.field-parameter select', $(this).closest('tr')).val();
             this.href += (this.href.indexOf('?')!= -1 ? '&' : '?') + 'parameter=' + id + '&hide_parameter';

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 setup(name='django-qshop',
-      version='0.4.0',
+      version='0.4.1',
       description='E-commerce for django. Requires django-sitemenu.',
       long_description='E-commerce for django. Requires django-sitemenu.',
       author='Vital Belikov',


### PR DESCRIPTION
Сорян! Переместив "parameter" в readonly_fields вызвало багу при нажатии кнопки "Save as new".
На ProductToParameter форме должны быть id параметров и имя параметров, но при этом избегать Select виджета ибо делается "SELECT * FROM `qshop_parameter` ORDER BY `qshop_parameter`.`order` ASC" для каждого параметра (а если параметров больше 15 это начинает жутко тормозить загрузку).
Поэтому parameter_id выносим в InputHidden, а название параметра через readonly_fields. Форма рендериться в 10х раз быстрее и save_formset получает parameter_id.
